### PR TITLE
Add field of view

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -2,6 +2,7 @@ from typing import Set, Iterable, Any
 
 from tcod.context import Context
 from tcod.console import Console
+from tcod.map import compute_fov
 
 from entity import Entity
 from game_map import GameMap
@@ -14,6 +15,7 @@ class Engine:
         self.event_handler = event_handler
         self.game_map = game_map
         self.player = player
+        self.update_fov()
 
     def handle_events(self, events: Iterable[Any]) -> None:
         for event in events:
@@ -24,11 +26,25 @@ class Engine:
 
             action.perform(self, self.player)
 
+            self.update_fov()  # Update the FOV before the player's next action.
+
+    def update_fov(self) -> None:
+        """Recompute the visible area based on the player's point of view."""
+        self.game_map.visible[:] = compute_fov(
+            self.game_map.tiles["transparent"],
+            (self.player.x, self.player.y),
+            radius=8,
+        )
+        # If a tile is "visible" it should be added to "explored".
+        self.game_map.explored |= self.game_map.visible
+
     def render(self, console: Console, context: Context) -> None:
         self.game_map.render(console)
 
         for entity in self.entities:
-            console.print(entity.x, entity.y, entity.char, fg=entity.color)
+            # Only print entities that are in the FOV
+            if self.game_map.visible[entity.x, entity.y]:
+                console.print(entity.x, entity.y, entity.char, fg=entity.color)
 
         context.present(console)
 

--- a/game_map.py
+++ b/game_map.py
@@ -9,13 +9,24 @@ class GameMap:
         self.width, self.height = width, height
         self.tiles = np.full((width, height), fill_value=tile_types.wall, order="F")
 
-        # Going to learn procedural generation, but may come back to building each locale from scratch
-        # self.tiles[30:33, 22] = tile_types.wall
+        self.visible = np.full((width, height), fill_value=False, order="F")  # Tiles the player can currently see
+        self.explored = np.full((width, height), fill_value=False, order="F")  # Tiles the player has seen before
 
     def in_bounds(self, x: int, y: int) -> bool:
         """Return True if x and y are inside of the bounds of this map."""
         return 0 <= x < self.width and 0 <= y < self.height
 
     def render(self, console: Console) -> None:
-        console.tiles_rgb[0:self.width, 0:self.height] = self.tiles["dark"]
+        """
+        Renders the map.
+
+        If a tile is in the "visible" array, then draw it with the "light" colors.
+        If it isn't, but it's in the "explored" array, then draw it with the "dark" colors.
+        Otherwise, the default is "SHROUD".
+        """
+        console.tiles_rgb[0:self.width, 0:self.height] = np.select(
+            condlist=[self.visible, self.explored],
+            choicelist=[self.tiles["light"], self.tiles["dark"]],
+            default=tile_types.SHROUD
+        )
 

--- a/tile_types.py
+++ b/tile_types.py
@@ -15,8 +15,9 @@ graphic_dt = np.dtype(
 tile_dt = np.dtype(
     [
         ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block POV.
-        ("dark", graphic_dt),  # Graphics for when this tile is not in POV.
+        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
+        ("light", graphic_dt),  # Graphics for when this tile is in FOV.
     ]
 )
 
@@ -26,15 +27,25 @@ def new_tile(
     walkable: int,
     transparent: int,
     dark: Tuple[int, Tuple[int, int, int], Tuple[int, int, int]],
+    light: Tuple[int, Tuple[int, int, int], Tuple[int, int, int]],
 ) -> np.ndarray:
     """Helper function for defining individual tile types """
-    return np.array((walkable, transparent, dark), dtype=tile_dt)
+    return np.array((walkable, transparent, dark, light), dtype=tile_dt)
 
+
+# SHROUD represents unexplored, unseen tiles
+SHROUD = np.array((ord(" "), (255, 255, 255), (0, 0, 0)), dtype=graphic_dt)
 
 floor = new_tile(
-    walkable=True, transparent=True, dark=(ord("."), (255, 255, 255), (0, 0, 0)),
+    walkable=True,
+    transparent=True,
+    dark=(ord("."), (80, 80, 80), (0, 0, 0)),
+    light=(ord("."), (255, 255, 255), (0, 0, 0)),
 )
 wall = new_tile(
-    walkable=False, transparent=False, dark=(ord("#"), (255, 255, 255), (0, 0, 0)),
+    walkable=False,
+    transparent=False,
+    dark=(ord("#"), (80, 80, 80), (0, 0, 0)),
+    light=(ord("#"), (255, 255, 255), (0, 0, 0)),
 )
 


### PR DESCRIPTION
Add field of view
- In addition to walkable and transparent, we now differentiate between dark and light tiles for what's known but currently in view or not
- Calculate field of view after each event
- Update explored to include the union of what was previously explored and what is now visible
- Render visible and explored as light and dark, respectively, and also now add shroud for things unseen and unknown which are rendered fully blank.